### PR TITLE
add instructions on how to install required Poweramp apk

### DIFF
--- a/poweramp_skin_sdk/poweramp_skin_sample/readme.md
+++ b/poweramp_skin_sdk/poweramp_skin_sample/readme.md
@@ -35,7 +35,7 @@ Skin development is done directly from Android Studio (3.2 was used for these sk
 ```
 additionalParameters "--shared-lib", "-I", "path to your Poweramp v3 APK"
 ```
-
+* your emulated device needs to have Poweramp v3 installed. Locate your Android\Sdk\platform-tools folder and copy the poweramp.apk into it. Open a shell and enter `./adb install demo.apk`
 * build and run skin as a normal Android app
 * when skin activity is started, "Start Poweramp With * Skin" button can be pressed to force Poweramp immediately reload the skin
 * skin should appear in Poweramp skin selection settings page as well


### PR DESCRIPTION
If you just follow the instructions given in the README, opening Poweramp from the built demo skin apk fails with a fatal exception. You seem to have to install Poweramp on the emulated device first.