### PR TITLE
Transparent Example: added windowIsFloating

### DIFF
--- a/poweramp_skin_sdk/poweramp_skin_sample/app/src/main/res/values/sample_skin_styles.xml
+++ b/poweramp_skin_sdk/poweramp_skin_sample/app/src/main/res/values/sample_skin_styles.xml
@@ -496,6 +496,7 @@
 	<style name="SampleSkin_transBgMain">
 		<item name="com.maxmpz.audioplayer:TopMilk">@style/SampleSkin_transBgMain_TopMilk</item>
 		<item name="android:windowShowWallpaper">true</item>
+		<item name="android:windowIsFloating">false</item>
 		<item name="android:windowBackground">@android:color/transparent</item>
 	</style>
 


### PR DESCRIPTION
Without that attribute the entire UI is fully broken and PowerAmp is not usable. See https://github.com/maxmpz/powerampapi/issues/23 for reference